### PR TITLE
feat: implement child account creation from frontend

### DIFF
--- a/frontend/api/ApiAccount.js
+++ b/frontend/api/ApiAccount.js
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import * as SecureStore from "expo-secure-store";
+
 import {API_BASE_URL} from '../config/Config';
 
 export const ApiAccount = async (body) => {
@@ -19,7 +21,7 @@ export const ApiSendCode = async (body) => {
         console.error("Error en ApiSendCode:", error);
         return error.response?.data || { error: "Error desconocido al enviar el código." };
     }
-}
+};
 
 export const ApiVerifyCode = async (body) => {
     try {
@@ -29,4 +31,25 @@ export const ApiVerifyCode = async (body) => {
         console.error("Error en ApiVerifyCode:", error);
         return error.response?.data || { error: "Error desconocido al verificar el código." };
     }
-}
+};
+
+export const ApiCreateKid = async (body) => {
+    try {
+        const token = await SecureStore.getItemAsync('accessToken');
+
+        const response = await axios.post(
+            `${API_BASE_URL}/api/kids/`,
+            body,
+            {
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            }
+        );
+
+        return response.data;
+    } catch (error) {
+        console.error("Error en ApiCreateKid:", error);
+        return error.response?.data || { error: "Error desconocido al crear el niño." };
+    }
+};

--- a/frontend/context/AuthContext.js
+++ b/frontend/context/AuthContext.js
@@ -7,7 +7,7 @@ export const AuthContext = createContext();
 export const AuthProvider = ({ children }) => {
     const [accessToken, setAccessToken] = useState(null);
 
-    // CArgar token al iniciar la app
+    // Cargar token al iniciar la app
     useEffect(() => {
        const loadToken = async () => {
            const token = await SecureStore.getItemAsync('accessToken');

--- a/frontend/screens/authentication/screen/CreateChildAccount.js
+++ b/frontend/screens/authentication/screen/CreateChildAccount.js
@@ -10,6 +10,7 @@ import {
 import CustomInput from '../../ui/components/CustomInput';
 import CustomButton from '../../ui/components/CustomButton';
 import DB from '../../../fakeDataBase/FakeDataBase';
+import {ApiCreateKid} from "../../../api/ApiAccount";
 
 const CreateChildAccount = () => {
     const navigation = useNavigation();
@@ -17,19 +18,22 @@ const CreateChildAccount = () => {
     const [childName, setChildName] = useState('');
     const [error, setError] = useState(false);
 
-    const handleSubmit = () => {
+    const handleSubmit = async () => {
         if (childName.trim() === '') {
             setError(true);
             return;
         }
 
-        const result = DB.confirmAccount(childName);
-        if (result) {
-            console.log("Cuenta creada correctamente de : " + childName + "con tutor de: " + result.name);
-            navigation.navigate("MainTabs");
-        } else {
+        const response = await ApiCreateKid({name:childName});
+
+        if (response.error) {
             setError(true);
+            console.error("Error al crear la cuenta del niño:", response.error);
+        } else {
+            console.log("Cuenta creada correctamente de:", response.name, "con niño: ", childName);
+            navigation.navigate("MainTabs");
         }
+
     };
 
     return (


### PR DESCRIPTION
Child account creation is now functional, sending the child's name as JSON to the backend. The authentication token is included in the request headers.