### PR TITLE
feat: add SessionProvider to handle global session from accessToken

### DIFF
--- a/frontend/.idea/workspace.xml
+++ b/frontend/.idea/workspace.xml
@@ -5,8 +5,11 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="182630bf-532f-45d8-82de-760fc9189d87" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/context/SessionContext.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/App.js" beforeDir="false" afterPath="$PROJECT_DIR$/App.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/package-lock.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -32,22 +35,22 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;integration&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;C:/Users/jorda/Documents/repo/JordaIn/Anfeca/back&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;C:\\Program Files\\JetBrains\\IntelliJ IDEA 2024.2.1\\plugins\\javascript-plugin\\jsLanguageServicesImpl\\external&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "git-widget-placeholder": "front",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "C:/Users/jorda/Documents/repo/JordaIn/Anfeca/frontend",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "ts.external.directory.path": "C:\\Program Files\\JetBrains\\IntelliJ IDEA 2024.2.1\\plugins\\javascript-plugin\\jsLanguageServicesImpl\\external",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="ReactDesignerToolWindowState">
     <option name="myId2Visible">
       <map>
@@ -85,6 +88,7 @@
       <workItem from="1743797151515" duration="6596000" />
       <workItem from="1743807959939" duration="6605000" />
       <workItem from="1744137744497" duration="199000" />
+      <workItem from="1744762369848" duration="6199000" />
     </task>
     <servers />
   </component>

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -35,6 +35,7 @@
     import { GuardianProvider } from './context/GuardianContext';
     import Profile from "./screens/profile/Profile";
     import {AuthContext, AuthProvider} from "./context/AuthContext";
+    import {SessionContext, SessionProvider} from "./context/SessionContext";
 
     const Stack = createStackNavigator();
     const Tab = createBottomTabNavigator();
@@ -147,15 +148,17 @@
 
     export default function App() {
         return (
-            <AuthProvider>
-                <AccountProvider>
-                    <GuardianProvider>
-                        <NavigationContainer>
-                            <StatusBar barStyle="light-content" backgroundColor="black" />
-                            <MainStack />
-                        </NavigationContainer>
-                    </GuardianProvider>
-                </AccountProvider>
-            </AuthProvider>
+            <SessionProvider>
+                <AuthProvider>
+                    <AccountProvider>
+                        <GuardianProvider>
+                            <NavigationContainer>
+                                <StatusBar barStyle="light-content" backgroundColor="black" />
+                                <MainStack />
+                            </NavigationContainer>
+                        </GuardianProvider>
+                    </AccountProvider>
+                </AuthProvider>
+            </SessionProvider>
         );
     }

--- a/frontend/context/SessionContext.js
+++ b/frontend/context/SessionContext.js
@@ -1,0 +1,53 @@
+import React, { createContext, useState, useEffect } from 'react';
+import jwt_decode from 'jwt-decode';
+import * as SecureStore from 'expo-secure-store';
+
+export const SessionContext = createContext();
+
+export const SessionProvider = ({ children }) => {
+    const [session, setSession] = useState({
+        accessToken: null,
+        accountId: null,
+        guardianId: null,
+        kidId: null,
+        profileType: null,
+    });
+
+    useEffect(() => {
+        const loadSession = async () => {
+            const token = await SecureStore.getItemAsync('accessToken');
+            if (token) {
+                updateSessionFromToken(token);
+            }
+        };
+        loadSession();
+    }, []);
+
+    const updateSessionFromToken = (token) => {
+        const decoded = jwt_decode(token);
+        setSession({
+            accessToken: token,
+            accountId: decoded.id,
+            guardianId: decoded.guardianId,
+            kidId: decoded.kidId || null,
+            profileType: decoded.profileType,
+        });
+    };
+
+    const clearSession = async () => {
+        await SecureStore.deleteItemAsync('accessToken');
+        setSession({
+            accessToken: null,
+            accountId: null,
+            guardianId: null,
+            kidId: null,
+            profileType: null,
+        });
+    };
+
+    return (
+        <SessionContext.Provider value={{ session, setSession, updateSessionFromToken, clearSession }}>
+            {children}
+        </SessionContext.Provider>
+    );
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "expo-font": "~13.0.4",
         "expo-secure-store": "~14.0.1",
         "expo-status-bar": "~2.0.1",
+        "jwt-decode": "^4.0.0",
         "lucide-react-native": "^0.486.0",
         "react": "18.3.1",
         "react-native": "0.76.8",
@@ -7176,6 +7177,15 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/kind-of": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "expo-font": "~13.0.4",
     "expo-secure-store": "~14.0.1",
     "expo-status-bar": "~2.0.1",
+    "jwt-decode": "^4.0.0",
     "lucide-react-native": "^0.486.0",
     "react": "18.3.1",
     "react-native": "0.76.8",


### PR DESCRIPTION
Added a new global context called SessionProvider that loads, decodes, and manages session data (accessToken, guardianId, kidId, profileType) from the JWT token. This enables conditional UI based on whether the active profile is a tutor or a kid.