### PR TITLE
fix: actualizar recompensas al regresar a la pantalla de Rewards

### DIFF
--- a/frontend/screens/rewards/Rewards.js
+++ b/frontend/screens/rewards/Rewards.js
@@ -36,11 +36,34 @@ const Rewards = () => {
 
     useFocusEffect(
         React.useCallback(() => {
-            if (!hasLoaded) {
-                fetchRewards();
-            }
-        }, [hasLoaded])
+            let isActive = true;
+
+            const loadRewards = async () => {
+                try {
+                    await ApiRefreshAccessToken();
+                    const response = await getAllRewards();
+                    if (isActive) {
+                        setRewards(response.rewardsArray);
+                        setHasLoaded(true);
+                        setLoading(false);
+                    }
+                } catch (error) {
+                    if (isActive) {
+                        console.error("Error fetching rewards:", error);
+                        setLoading(false);
+                    }
+                }
+            };
+
+            setLoading(true);
+            loadRewards();
+
+            return () => {
+                isActive = false;
+            };
+        }, [])
     );
+
 
     return (
         <View style={styles.container}>


### PR DESCRIPTION
- Se corrige el useFocusEffect para que siempre se refresquen las recompensas al volver a la pantalla.
- Se elimina la dependencia de hasLoaded, ya que causaba que no se actualizaran los datos después de agregar o editar recompensas.
- Mejora de la experiencia de usuario al mantener la lista siempre actualizada.