### PR TITLE
fix: actualizar preguntas al regresar a la pantalla de Questions

### DIFF
--- a/frontend/screens/home/screens/Questions.js
+++ b/frontend/screens/home/screens/Questions.js
@@ -36,10 +36,8 @@ const Questions = ({ route, navigation }) => {
 
     useFocusEffect(
         useCallback(() => {
-            if (!hasLoaded) {
-                fetchQuestions();
-            }
-        }, [hasLoaded])
+            fetchQuestions();
+        }, [])
     );
 
     return (


### PR DESCRIPTION
- Se corrige el useFocusEffect para que siempre se refresquen las preguntas al volver a la pantalla.
- Se elimina la dependencia de hasLoaded, ya que provocaba que no se actualizaran los datos después de agregar o editar preguntas.
- Mejora de la experiencia de usuario al mantener la lista siempre actualizada.